### PR TITLE
Add valid data flag

### DIFF
--- a/xiaomi-ble.js
+++ b/xiaomi-ble.js
@@ -105,9 +105,10 @@ module.exports = function(RED) {
 			var send = function() {
 				if (!sent) {
 					if (Object.keys(msg).length > 0) {
-						node.send({payload: msg, address: peripheral.address});
+						node.send({payload: msg, address: peripheral.address, valid_data: true});
 						node.status({});
 					} else {
+						node.send({payload: msg, address: peripheral.address, valid_data: false});
 						node.status({fill:"red", shape:"dot", text:"no data"});
 					}
 					sent = true;


### PR DESCRIPTION
I have found the temperature sensor to be a little unreliable.

I propose always returning a response and adding a `data_valid` item to the returned message.

This only covers the case where data is actually being sent. As there are a number of other occasions where data is not returned, where an error or a warn should be raised.  A second output with a status code could be used.

BTW this is a great node!

Cheers