### PR TITLE
Bugfix: change noble dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"email": "eschava@gmail.com"
   },
   "dependencies": {
-    "noble": "^1.8.1"
+    "@abandonware/noble": "^1.9.2-5"
   },
   "description": "Xiaomi Bluetooth4 (BLE) sensors",
   "devDependencies": {},

--- a/package.json
+++ b/package.json
@@ -33,5 +33,5 @@
     "url": "git+https://github.com/eschava/node-red-contrib-xiaomi-ble.git"
   },
   "optionalDependencies": {},
-  "version": "1.2.3"
+  "version": "1.2.4"
 }

--- a/xiaomi-ble.js
+++ b/xiaomi-ble.js
@@ -1,7 +1,7 @@
 module.exports = function(RED) {
     "use strict";
 
-    var noble = require('noble');
+    var noble = require('@abandonware/noble');
 	
     function XiaomiBleNode(config) {
         RED.nodes.createNode(this, config);


### PR DESCRIPTION
Changed `noble` dependency to maintained package `@abandonware/noble`. `@abandonware/noble is fork of the previous package and it looks like it's compatible. After this dependency change, the node started working for me.